### PR TITLE
feat: disable trigger workflow for dependabot

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-20.04
+    if: ${{ github.actor != 'dependabot[bot]' }}
 
     env:
       DOCKER_IMAGE: rnapdbee-image
@@ -42,6 +43,8 @@ jobs:
   
   lint:
     runs-on: ubuntu-20.04
+    if: ${{ github.actor != 'dependabot[bot]' }}
+
     strategy:
       matrix:
         python-version: ["3.8", "3.10"]


### PR DESCRIPTION
Due to Github Actions limits I have to disable workflow for dependabot. 